### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,6 @@
 name: Build website
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/braswelljr/colored/security/code-scanning/1](https://github.com/braswelljr/colored/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block to restrict the GITHUB_TOKEN to the least privilege necessary. In this case, the workflow only checks out code, installs dependencies, and builds the project, so it only needs read access to repository contents. The best way to fix this is to add a `permissions` block at the top level of the workflow (just after the `name:` and before `on:`), setting `contents: read`. This will apply to all jobs in the workflow unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
